### PR TITLE
Add content to working mode page

### DIFF
--- a/WorkMode/guiding_principles.md
+++ b/WorkMode/guiding_principles.md
@@ -5,9 +5,22 @@ layout: default
 # DID Working Group Guiding Principles
 {: .no_toc}
 
-This document sets down the current guiding principles in use by the DID 1.1 Working Group to assist in making decisions about specification features. These guidelines provide a framework in which to have productive discussions that quickly come to consensus, rather than ending up blocked in an unresolvable tug-of-war over opposing and equally valid points of view. The principles are not meant to be interpreted as strict or objective rules, but instead as informative of the overall direction of the group to promote consistency and usability of the resulting specifications. 
+This document sets down the current guiding principles in use by the DID
+Working Group to assist in making decisions about specification features.
+These guidelines provide a framework in which to have productive
+discussions that quickly come to consensus, rather than ending up blocked
+in an unresolvable tug-of-war over opposing and equally valid points of
+view. The principles are not meant to be interpreted as strict or objective
+rules, but instead as informative of the overall direction of the group to
+promote consistency and usability of the resulting specifications. 
 
-This document is a *Living Document* and as such will change. Members of the group are encouraged to edit (e.g. to update, correct, etc.) the information. Comments about this document are welcome via issues and pull request on the [group’s “admin” repository](https://github.com/w3c/did-wg/) or via emails sent to the group’s [`public-did-wg@w3.org`](mailto:public-did-wg@w3.org) e-mail list, using a subject prefix of <code>[Principles] …</code>.
+This document is a *Living Document* and as such will change. Members of
+the group are encouraged to edit (e.g. to update, correct, etc.) the
+information. Comments about this document are welcome via issues and pull
+request on the [group’s “admin” repository](https://github.com/w3c/did-wg/)
+or via emails sent to the group’s
+[`public-did-wg@w3.org`](mailto:public-did-wg@w3.org) e-mail list, using a
+subject prefix of <code>[Principles] …</code>.
 
 **Table of Content**
 * TOC
@@ -17,7 +30,10 @@ This document is a *Living Document* and as such will change. Members of the gro
 
 ## Stay on target!
 
-We follow our overall mission to standardize the DID URI scheme, the data model and syntax of DID Documents, which contain information related to DIDs that enable the aforementioned initial use cases, and the requirements for DID Method specifications.
+We follow our overall mission to standardize
+* the DID URI scheme, 
+* the data model and syntax of DID Documents, 
+* and the requirements for DID Method specifications.
 
 **Notes**
 
@@ -25,55 +41,94 @@ We follow our overall mission to standardize the DID URI scheme, the data model 
 
 ## Require real use cases, with actual instance data.
 
-Features are supported by real world use cases, with actual data that can be referenced. This helps reduce entirely theoretical features that might be implemented in libraries, but never used in practice by producers or consumers.
+Features are supported by real world use cases, with actual data that can
+be referenced. This helps reduce entirely theoretical features that might
+be implemented in libraries, but never used in practice by producers or
+consumers.
 
 **Notes**
 
-* Use cases should be supporting material to provide rationale for decisions, and a teaching tool for when features might be useful. They are not a design requirements gathering tool, and the group is not starting from an empty slate.
-* These use cases are collected on a wiki page, with the option of publishing a Note or integrating in to the specifications.
+* Use cases should be supporting material which provides rationale for
+    decisions, and a teaching tool for when features might be useful. They
+    are not a design requirements gathering tool, and the group is not
+    starting from an empty slate.
+* These use cases are collected in a [Use Cases document](https://github.com/w3c/did-use-cases),
+    which will be published as a Note.
 
 ## Require at least two supporters for each use case.
 
-As the mission is interoperability, having at least two supporters for each use case is important. If only one supporter can be found, then any features that it would require are likely too specific for inclusion in the proposed form.
+As the mission is interoperability, having at least two supporters for each
+use case is important. If only one supporter can be found, then any
+features that it would require are likely too specific for inclusion in the
+proposed form.
 
 **Notes**
 
-* Any independent organization, group or individual can be a supporter, regardless of whether they are part of the Working Group, or even members of the W3C. Consortia or other standards organizations that represent many participants can thus fulfill this principle via their members.
-* This is orthogonal to implementations of the specifications, which are required to exit Candidate Recommendation phase.
+* Any independent organization, group or individual can be a supporter,
+    regardless of whether they are part of the Working Group, or members of
+    the W3C. Consortia or other standards organizations that represent many
+    participants can thus fulfill this principle via their members.
+* This is orthogonal to implementations of the specifications, which are
+    required to exit Candidate Recommendation phase.
 
 ## As simple as possible, but no simpler.
 
-A simpler solution (to understand, implement and use) is better than a more complex solution that accomplishes the same result.
+A simpler solution (to understand, implement and use) is better than a more
+complex solution that accomplishes the same result.
 
 ## Consistency is simpler than exceptions.
 
-Simplicity is considered in aggregate for the set of features defined by a specification, not independently.  If the same set of features can be accomplished by a smaller number of more consistent patterns, then that method is (very likely) simpler. Memorizing exceptions is harder than memorizing and applying rules.
+Simplicity is considered in aggregate for the set of features defined by a
+specification, not independently.  If the same set of features can be
+accomplished by a smaller number of more consistent patterns, then that
+method is (very likely) simpler. Memorizing exceptions is harder than
+memorizing and applying rules.
 
 ## Usability is determined by end users, not library implementers.
 
-Usability is determined by the target audience (data producers and consumers) based on their experience of understanding and applying the specification via existing implementations, not by the experience of implementers of the specification text directly. If there is a feature that makes it harder for implementations, but easier/better for end users, then that is a worthwhile trade off. We follow the HTML Design Pattern documents notion of the [Priority of Constituencies](https://www.w3.org/TR/html-design-principles/#priority-of-constituencies), with an emphasis on trying to make things better for everyone. 
+Usability is determined by the target audience (data producers and
+consumers) based on their experience of understanding and applying the
+specification via existing implementations, not by the experience of
+implementers of the specification text directly. If there is a feature
+that makes it harder for implementations, but easier/better for end users,
+then that is a worthwhile trade off. We follow the HTML Design Pattern
+documents notion of the 
+[Priority of Constituencies](https://www.w3.org/TR/html-design-principles/#priority-of-constituencies),
+with an emphasis on trying to make things better for everyone. 
 
 **Notes**
 
-* Issues might arise where we need to prioritize between producers and consumers of the DID. The general feeling is that, in that situation, we should prioritize consumer happiness over producer happiness... the usability of the data, rather than ease of creation.
+* Issues might arise where we need to prioritize between producers and
+consumers of the DID. The general feeling is that, in that situation, we
+should prioritize consumer happiness over producer happiness, i.e., the
+usability of the data, rather than ease of creation.
   
 
 ## Provide on-ramps.
 
 A solution that can be implemented in incremental stages is better than a
 solution that is all or nothing, as not everyone needs every feature but
-many people need various parts. Complex patterns should build upon simple ones, sometimes making them patterns more complicated than if they were built in isolation.
+many people need various parts. Complex patterns should build upon simple
+ones, sometimes making the patterns more complicated than if they were
+built in isolation.
 
 ## Define success, not failure.
 
-The specifications are defined in terms of what it means to be conformant, and not patterns that are not conformant.  The fewer constraints we require, the easier to have non-breaking changes in the future and the easier it is to have experimentation. In a similar way to the distinction between Open World and Closed World, if something is not defined by the specification then it is permissible (just not standardized) rather than being disallowed.
+The specifications are defined in terms of what it means to be conformant,
+and not patterns that are not conformant. The fewer constraints we require,
+the easier to have non-breaking changes in the future and the easier it is
+to have experimentation. In a similar way to the distinction between Open
+World and Closed World, if something is not defined by the specification
+then it is permissible (just not standardized) rather than being disallowed.
 
 **Notes**
 
-* This is hard to judge when it is appropriate to be prescriptive, and when it is appropriate to be silent. Several issues have arisen on both sides -- sometimes 1.0 is too prescriptive, sometimes the definition is not precise enough.
+* It is hard to judge when it is appropriate to be prescriptive, and when
+    it is appropriate to be silent. Several issues have arisen on both
+    sides -- sometimes 1.0 is too prescriptive, sometimes the definition is
+    not precise enough.
 
 ## Follow existing standards and best practices, where possible and where they do not conflict with other principles.
 
 Between invention and reuse, pick reuse... unless that reuse would
 demonstrably harm adoption by being more complicated than necessary.
-

--- a/WorkMode/guiding_principles.md
+++ b/WorkMode/guiding_principles.md
@@ -125,8 +125,6 @@ then it is permissible (just not standardized) rather than being disallowed.
 
 * It is hard to judge when it is appropriate to be prescriptive, and when
     it is appropriate to be silent.
-    sides -- sometimes 1.0 is too prescriptive, sometimes the definition is
-    not precise enough.
 
 ## Follow existing standards and best practices, where possible and where they do not conflict with other principles.
 

--- a/WorkMode/guiding_principles.md
+++ b/WorkMode/guiding_principles.md
@@ -15,7 +15,7 @@ rules, but instead as informative of the overall direction of the group to
 promote consistency and usability of the resulting specifications. 
 
 This document is a *Living Document* and as such will change. Members of
-the group are encouraged to edit (e.g. to update, correct, etc.) the
+the group are encouraged to edit (e.g., to update, correct, etc.) the
 information. Comments about this document are welcome via issues and pull
 request on the [group’s “admin” repository](https://github.com/w3c/did-wg/)
 or via emails sent to the group’s
@@ -64,8 +64,8 @@ proposed form.
 
 **Notes**
 
-* Any independent organization, group or individual can be a supporter,
-    regardless of whether they are part of the Working Group, or members of
+* Any independent organization, group, or individual can be a supporter,
+    regardless of whether they are part of the Working Group, or a member of
     the W3C. Consortia or other standards organizations that represent many
     participants can thus fulfill this principle via their members.
 * This is orthogonal to implementations of the specifications, which are
@@ -73,7 +73,7 @@ proposed form.
 
 ## As simple as possible, but no simpler.
 
-A simpler solution (to understand, implement and use) is better than a more
+A solution that is simpler (to understand, implement, and use) is better than a more
 complex solution that accomplishes the same result.
 
 ## Consistency is simpler than exceptions.

--- a/WorkMode/guiding_principles.md
+++ b/WorkMode/guiding_principles.md
@@ -124,7 +124,7 @@ then it is permissible (just not standardized) rather than being disallowed.
 **Notes**
 
 * It is hard to judge when it is appropriate to be prescriptive, and when
-    it is appropriate to be silent. Several issues have arisen on both
+    it is appropriate to be silent.
     sides -- sometimes 1.0 is too prescriptive, sometimes the definition is
     not precise enough.
 

--- a/WorkMode/index.md
+++ b/WorkMode/index.md
@@ -140,7 +140,7 @@ face-to-face meetings as observers. Non-members have not made any commitment
 to provide standard W3C royalty-free licensing, so non-members are restricted
 to observer status only. Observers may listen, and participate in general
 discussions during the meeting. However, they must not make technical
-contributions, or attempt to influence an approach to a feature that may
+contributions, nor attempt to influence an approach, to a feature that may
 become part of the specification being discussed.
 
 If the public contributor, or the observer, works for a W3C member company,

--- a/WorkMode/index.md
+++ b/WorkMode/index.md
@@ -79,8 +79,7 @@ meeting and its agenda are announced **at least 24 hours** before the
 meeting begins. Minutes are taken for every meeting and are automatically
 published after the meeting in a provisional format. A more readable,
 cleaned-up format is published usually within 24 hours after the meeting
-ends. These minutes are considered as “Drafts” until they are approved at
-the next teleconference when they become official.
+ends. 
 
 The charter also states that:
 
@@ -96,10 +95,10 @@ The charter also states that:
     response period, the resolution will be considered to have obtained
     consensus as a resolution of the Working Group.
 
-By default, publication of the draft meeting minutes is considered as a
-call for consensus for any formal resolution therein. However, depending
-on the assessment and the importance of a specific resolution at hand, the
-chairs may issue an more explicit CfC by email when the issue requires more
+By default, publication of the meeting minutes is considered as a call for
+consensus for any formal resolution therein. However, depending on the
+assessment and the importance of a specific resolution at hand, the chairs
+may issue an more explicit CfC by email when the issue requires more
 details and explanations.
 
 #### Face-to-face meetings

--- a/WorkMode/index.md
+++ b/WorkMode/index.md
@@ -89,7 +89,7 @@ The charter also states that:
 >
 > A call for consensus (CfC) will be issued for all resolutions (for
     example, via email and/or web-based survey), with a response period
-    from one week to 10 working days, depending on the chair's evaluation
+    from 5 to 10 working days, depending on the chair's evaluation
     of the group consensus on the issue.
 >
 > If no objections are raised on the mailing list by the end of the
@@ -116,7 +116,7 @@ face-to-face meeting week (a.k.a “TPAC”) and this group typically has a f2f
 meeting during that week. The dates/locations are generally known a year or
 more in advance.
 
-For the minutes, resolutions, and consensus achieved at the f2f meetings
+For the minutes, resolutions, and consensus achieved at the f2f meetings,
 the same [rules](#telco) as for teleconferences apply.
 
 #### Scribing
@@ -126,9 +126,9 @@ and expect all WG members who are able to scribe to do so.
 ### Public participation
 It is possible for people who are not members of the DID WG to follow the
 Working Group's work by signing up to the group's public mailing list,
-read the mailing list archives, or watch the github issues. They can also
-raise issues on github and the Working Group is required to answer to those
-issues within a reasonable time. The chairs of the Working Group may also
+reading the mailing list archives, or watching the github issues. They can also
+raise issues on github, which the Working Group is required to answer
+within a reasonable time. The chairs of the Working Group may also
 occasionally invite them for a teleconference to, e.g., discuss those issues.
 In the case of a specific contribution to the specification in the form of,
 e.g., a Pull Request, see the
@@ -149,7 +149,7 @@ make them a DID WG participant.
 
 Please note that this is to provide as much protection as possible through
 the W3C Patent Policy. We take the royalty-free status of W3C standards
-very seriously, and any attempt to work-around these basic requirements
+very seriously, and any attempt to work around these basic requirements
 would be considered a serious breach of meeting participation.
 
 ### GitHub
@@ -172,8 +172,8 @@ Other members of the group are encouraged to use the
 when contributing to the text: work on a forked repository and issue a pull
 request on the main repository for that document when the contribution is
 ready. Editors should use the pull request mechanism (except for obvious,
-grammatical or stylistic changes), albeit they can choose to do that
-directly on the core repository.
+grammatical, or stylistic changes), albeit they can choose to do that
+directly on the core repository (i.e., without creating a distinct fork).
 
 (If you are new to GitHub, the
 [*“Introduction to Basic GitHub Contribution”*](https://iherman.github.io/misc-notes/docs/BasicGitHubContributionIntro)
@@ -182,11 +182,11 @@ may be of help.)
 In line with the spirit of the asynchronous decision procedures outlined
 above, significant pull requests, as well as the closure of open issues,
 should be marked with a special label (to be defined) and left open for a
-week. If no objection is raised during that time the issue can be closed or
+week. If no objection is raised during that time, the issue can be closed or
 the pull request can be merged, respectively.
 
 #### Issue labels
-GitHub issues are also used as a records of wide reviews, of horizontal
+GitHub issues are also used as a record of wide reviews, of horizontal
 reviews, etc. The Working Group will define a number of labels (e.g.,
 labeling an issue as part of the Horizontal Security review). Chairs,
 staff, and editors are responsible to set those labels accordingly.
@@ -253,7 +253,7 @@ status.
 
 The [Charter](https://www.w3.org{{ site.charter }}) and the
 [W3C Process Document](https://www.w3.org/Consortium/Process/) are the
-final arbiters of any process question, however the Working Group has
+final arbiters of any process question; however, the Working Group has
 adopted some complimentary, additional processes to aid in its productivity.
 
 * Adoption of [guiding technical principles](guiding_principles) towards
@@ -268,7 +268,7 @@ adopted some complimentary, additional processes to aid in its productivity.
     * Any decision to merge may be challenged during a 48-hour window
         following the decision.
 * It is encouraged that any Pull Request which changes the normative text
-    of the [DID Specification](https://github.com/w3c/did-spec) will be
+    of the [DID Specification](https://github.com/w3c/did-spec) be
     accompanied by an equivalent Pull Request which changes the appropriate
     tests in the [Test Suite](https://github.com/w3c/did-test-suite).
     

--- a/WorkMode/index.md
+++ b/WorkMode/index.md
@@ -17,7 +17,7 @@ contains additional information about how the group *really* works, so this
 information may be particularly useful to new members of the group.
 
 This document is a *Living Document* and as such will change. Members of
-the group are encouraged to edit (e.g. to update, correct, etc.) the
+the group are encouraged to edit (e.g., to update, correct, etc.) the
 information. Comments about this document are welcome via issues and pull
 requests on the [group’s “admin” repository](https://github.com/w3c/did-wg/)
 or via emails sent to the group’s [`public-did-wg@w3.org`](mailto:public-did-wg@w3.org)
@@ -56,7 +56,7 @@ A WG member is added to the group’s lists `public-did-wg@w3.org` and
 more details. Other mailing lists may be set up for task forces or other
 sub-committees; signing up to those list must be done manually.
 
-Participation from the Public (i.e., non group members), via our Public
+Participation from the Public (i.e., non group members) via our Public
 e-mail lists is also welcome, provided comments, contributions, etc., are
 consistent with the [W3C Patent Policy](https://www.w3.org/TR/patent-policy/).
 

--- a/WorkMode/index.md
+++ b/WorkMode/index.md
@@ -5,13 +5,25 @@ layout: default
 # DID Working Group Work mode
 {: .no_toc}
 
-This document defines and describes the DID WG's *Real Work Modes*, including Participation and Communication, Meetings, Calls for Consensus, Mail List usage, and links to important resources.
+This document defines and describes the DID WG's *Real Work Modes*, 
+including Participation and Communication, Meetings, Calls for Consensus, 
+Mail List usage, and links to important resources.
 
-Note that the [WG's Charter](https://www.w3.org{{ site.charter }}) formally defines the general framework of the group's working mode. In all cases, the Charter and/or the [W3C Process Document](//www.w3.org/Consortium/Process/) overrides the information in this document. Nevertheless, this document contains additional information about how the group *really* works, so this information may be particularly useful to new members of the group.
+Note that the [WG's Charter](https://www.w3.org{{ site.charter }}) formally
+defines the general framework of the group's working mode. In all cases,
+the Charter and/or the [W3C Process Document](//www.w3.org/Consortium/Process/) 
+overrides the information in this document. Nevertheless, this document
+contains additional information about how the group *really* works, so this
+information may be particularly useful to new members of the group.
 
-This document is a *Living Document* and as such will change. Members of the group are encouraged to edit (e.g. to update, correct, etc.) the information. Comments about this document are welcome via issues and pull request on the [group’s “admin” repository](https://github.com/w3c/did-wg/) or via emails sent to the group’s [`public-did-wg@w3.org`](mailto:public-did-wg@w3.org) e-mail list, using a subject prefix of <code>[WorkMode]…</code>.
+This document is a *Living Document* and as such will change. Members of
+the group are encouraged to edit (e.g. to update, correct, etc.) the
+information. Comments about this document are welcome via issues and pull
+requests on the [group’s “admin” repository](https://github.com/w3c/did-wg/)
+or via emails sent to the group’s [`public-did-wg@w3.org`](mailto:public-did-wg@w3.org)
+e-mail list, using a subject prefix of <code>[WorkMode]…</code>.
 
-**Table of Content**
+**Table of Contents**
 * TOC
 {:toc}
 
@@ -19,24 +31,41 @@ This document is a *Living Document* and as such will change. Members of the gro
 
 ## Participation and Communication
 
-The group's formal Participation and Communication models are documented in the [Participation](https://www.w3.org/2019/03/jsonld-wg-charter.html#participation) and [Communications](https://www.w3.org/2019/03/jsonld-wg-charter.html#communication) sections of its Charter, respectively.
+The group's formal Participation and Communication models are documented in
+the [Participation](https://www.w3.org/2019/09/did-wg-charter.html#participation)
+and [Communications](https://www.w3.org/2019/09/did-wg-charter.html#communication)
+sections of its Charter, respectively.
 
 A WG member may participate in various ways including:
 
 * Attending any of the group‘s [weekly teleconferences or F2F meetings](../Meetings/)
-* Participating in discussions on the group’s primary mail lists (see below), and/or a specification’s GitHub repository by way of Issues and Pull Requests. (See the [list of all repositories](https://github.com/search?q=topic%3Adid-wg+org%3Aw3c&type=Repositories) of this Group.) 
+* Participating in discussions on the group’s primary mail lists (see below),
+    and/or a specification’s GitHub repository by way of Issues and Pull
+    Requests. (See the 
+    [list of all repositories](https://github.com/search?q=topic%3Adid-wg+org%3Aw3c&type=Repositories)
+    of this Group.) 
 * Participating in discussions on the group’s `#did` IRC channel
+* Serving as a scribe during a WG meeting.
 * Being an Editor of one or more of the group’s [active specifications](https://www.w3.org/2019/did-wg/PublStatus)
-* Being an implementer for one of the specifications (proof-of-concept implementations are fine!)
+* Being an implementer for one of the specifications (proof-of-concept
+    implementations are fine!)
 * Contributing tests for the group’s [specifications](https://www.w3.org/2019/did-wg/PublStatus)
 
-A WG member is added to the group’s lists `public-did-wg@w3.org` and `member-did-wg@w3.org`; see the [separate section](#communications) for more details. Other mailing lists may be set up for task forces or other sub-committees; signing up to those list must be done manually.
+A WG member is added to the group’s lists `public-did-wg@w3.org` and
+`member-did-wg@w3.org`; see the [separate section](#communications) for
+more details. Other mailing lists may be set up for task forces or other
+sub-committees; signing up to those list must be done manually.
 
-Participation from the Public (i.e., non group members), via our Public e-mail lists is also welcome, provided comments, contributions, etc., are consistent with the [W3C Patent Policy](https://www.w3.org/TR/patent-policy/).
+Participation from the Public (i.e., non group members), via our Public
+e-mail lists is also welcome, provided comments, contributions, etc., are
+consistent with the [W3C Patent Policy](https://www.w3.org/TR/patent-policy/).
 
 ### Information for “Newbies” — New Group Members
 
-*New members of the group are strongly encouraged to read the group’s [Newbie](newbie) document which includes links to important resources.* New members are also encouraged to send a short introductory e-mail to the group's [primary mail list](https://lists.w3.org/Archives/Public/public-did-wg/).
+*New members of the group are strongly encouraged to read the group’s
+[Newbie](newbie) document which includes links to important resources.* New
+members are also encouraged to send a short introductory e-mail to the
+group's [primary mail list](https://lists.w3.org/Archives/Public/public-did-wg/).
 
 ## Communications
 
@@ -45,92 +74,224 @@ Participation from the Public (i.e., non group members), via our Public e-mail l
 #### Teleconferences
 {: #telco}
 
-Teleconferences are held weekly at a time agreed upon by the group. The meeting and its agenda is announced **at least 24 hours** before the meeting begins. Minutes are taken for every meeting and are automatically published after the meeting in a provisional format. A more readable, cleaned-up format is published usually within 24 hours after the meeting ends. These minutes are considered as “Drafts” until they are approved at the next teleconference when they become official.
+Teleconferences are held weekly at times agreed upon by the group. The
+meeting and its agenda are announced **at least 24 hours** before the
+meeting begins. Minutes are taken for every meeting and are automatically
+published after the meeting in a provisional format. A more readable,
+cleaned-up format is published usually within 24 hours after the meeting
+ends. These minutes are considered as “Drafts” until they are approved at
+the next teleconference when they become official.
 
-The charter also says that:
+The charter also states that:
 
-> …any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional.
+> …any resolution (including publication decisions) taken in a face-to-face
+    meeting or teleconference will be considered provisional.
 >
-> A call for consensus (CfC) will be issued for all resolutions (for example, via email and/or web-based survey), with a response period from one week to 10 working days, depending on the chair's evaluation of the group consensus on the issue.
+> A call for consensus (CfC) will be issued for all resolutions (for
+    example, via email and/or web-based survey), with a response period
+    from one week to 10 working days, depending on the chair's evaluation
+    of the group consensus on the issue.
 >
-> If no objections are raised on the mailing list by the end of the response period, the resolution will be considered to have obtained consensus as a resolution of the Working Group.
+> If no objections are raised on the mailing list by the end of the
+    response period, the resolution will be considered to have obtained
+    consensus as a resolution of the Working Group.
 
-By default, publication of the draft meeting minutes is considered as a call for consensus for any formal resolution therein. However, depending on the assessment and the importance of a specific resolution at hand, the chairs may issue an more explicit CfC by email when the issue requires more details and explanations.
+By default, publication of the draft meeting minutes is considered as a
+call for consensus for any formal resolution therein. However, depending
+on the assessment and the importance of a specific resolution at hand, the
+chairs may issue an more explicit CfC by email when the issue requires more
+details and explanations.
 
 #### Face-to-face meetings
-For Face-to-face meetings, there **should** be **8 weeks** notice of the city and date/time. Exact venue information is not required so early, but it is helpful especially in large cities so people traveling can get appropriate accommodation. The chairs and staff can help organize invitations for people who need them to obtain a visa, given sufficient notice.
+For Face-to-face meetings, there **should** be **8 weeks** notice of the
+city and date/time. Exact venue information is not required so early, but
+it is helpful, especially in large cities, so people traveling can find
+appropriate accommodations. The chairs and staff can help organize
+invitations for people who need them to obtain a visa, given sufficient
+notice.
 
-The consortium usually has an annual [“Technical Plenary and All Working Group”](https://www.w3.org/2002/09/TPOverview.html) face-to-face meeting week (a.k.a “TPAC”) and this group typically has a f2f meeting during that week. The dates/locations are generally known a year or more in advance.
+The consortium usually has an annual 
+[“Technical Plenary and All Working Group”](https://www.w3.org/2002/09/TPOverview.html)
+face-to-face meeting week (a.k.a “TPAC”) and this group typically has a f2f
+meeting during that week. The dates/locations are generally known a year or
+more in advance.
 
-For the minutes, resolutions, and consensus achieved at the f2f meetings the same [rules](#telco) as for teleconferences apply.
+For the minutes, resolutions, and consensus achieved at the f2f meetings
+the same [rules](#telco) as for teleconferences apply.
+
+#### Scribing
+We encourage all WG members to take turns serving as scribe for meetings,
+and expect all WG members who are able to scribe to do so.
 
 ### Meeting observers
-It is possible for people who are not members of the DID WG to attend meetings as observers. Non-members have not made any commitment to provide standard W3C royalty-free licensing, so non-members are restricted to observer status only.
+It is possible for people who are not members of the DID WG to attend
+meetings as observers. Non-members have not made any commitment to provide
+standard W3C royalty-free licensing, so non-members are restricted to
+observer status only.
 
-Observers may listen, and participate in general discussions during the meeting. However, they must not make technical contributions, or attempt to influence an approach to a feature that may become part of the specification being discussed.
+Observers may listen, and participate in general discussions during the
+meeting. However, they must not make technical contributions, or attempt to
+influence an approach to a feature that may become part of the
+specification being discussed.
 
-If the attendee works for a W3C member company, they are encouraged to ask their Advisory Committee (AC) representative to make them a Web Platform WG participant. Alternatively, their AC representative can make a formal [royalty-free licensing commitment](https://www.w3.org/2004/01/pp-impl/{{ site.groupid }}/join). They can then fully participate in the meeting.
+If the attendee works for a W3C member company, they are encouraged to ask
+their Advisory Committee (AC) representative to make them a DID WG
+participant. Alternatively, their AC representative can make a formal
+[royalty-free licensing commitment](https://www.w3.org/2004/01/pp-impl/{{ site.groupid }}/join).
+They can then fully participate in the meeting.
 
-Please note that this is to provide as much protection as possible through the W3C Patent Policy. We take the royalty-free status of W3C standards very seriously, and any attempt to work-around these basic requirements would be considered a serious breach of meeting participation.
+Please note that this is to provide as much protection as possible through
+the W3C Patent Policy. We take the royalty-free status of W3C standards
+very seriously, and any attempt to work-around these basic requirements
+would be considered a serious breach of meeting participation.
 
 ### GitHub
 {: #github}
 
-The group makes an extensive usage of GitHub. Each major deliverables is managed in its own, separate repository (a [complete list of repositories](https://github.com/search?q=topic%3Adid-wg+org%3Aw3c&type=Repositories) is available). The group intends to use the repositories’ issue management extensively to discuss technical problems and propose solutions.
+The WG cannot make progress only during its weekly teleconferences. The
+group makes extensive use of GitHub. Each major deliverable is managed
+in its own, separate repository (a 
+[complete list of repositories](https://github.com/search?q=topic%3Adid-wg+org%3Aw3c&type=Repositories)
+is available). The group intends to use the repositories’ issue management
+extensively to discuss technical problems and propose solutions. It is
+expected that most of this discussion will occur outside of our regular
+meeting times. 
 
-Editors of the documents (as well as the chairs and the W3C staff) have the necessary access right to make editorial changes on the specifications directly using the standard Git(Hub) commits and merging pull requests. Other members of the group are encouraged to use the [“fork and pull model”](https://help.github.com/articles/about-collaborative-development-models/) when contributing to the text: work on a forked repository and issue a pull request on the main repository for that document when the contribution is ready. Editors should use the pull request mechanism (except for obvious, grammatical or stylistic changes), albeit they can choose to do that directly on the core repository.
+Editors of the documents (as well as the chairs and the W3C staff) have the
+necessary access rights to make editorial changes on the specifications
+directly using the standard Git(Hub) commits and by merging pull requests.
+Other members of the group are encouraged to use the
+[“fork and pull model”](https://help.github.com/articles/about-collaborative-development-models/)
+when contributing to the text: work on a forked repository and issue a pull
+request on the main repository for that document when the contribution is
+ready. Editors should use the pull request mechanism (except for obvious,
+grammatical or stylistic changes), albeit they can choose to do that
+directly on the core repository.
 
-(If you are new to GitHub, the [*“Introduction to Basic GitHub Contribution”*](https://iherman.github.io/misc-notes/docs/BasicGitHubContributionIntro) may be of help.)
+(If you are new to GitHub, the
+[*“Introduction to Basic GitHub Contribution”*](https://iherman.github.io/misc-notes/docs/BasicGitHubContributionIntro)
+may be of help.)
 
-In line with the spirit of the asynchronous decision procedures outlined above, significant pull requests, as well as the closure of open issues, should be marked with a special label (to be defined) and leave it open for a week. If no objection is raised during that time the issue can be closed or the pull request can be merged, respectively.
+In line with the spirit of the asynchronous decision procedures outlined
+above, significant pull requests, as well as the closure of open issues,
+should be marked with a special label (to be defined) and left open for a
+week. If no objection is raised during that time the issue can be closed or
+the pull request can be merged, respectively.
 
 #### Issue labels
 
-GitHub issues are also used as a records of wide reviews, of horizontal reviews, etc. The Working Group will define a number of labels (e.g., labeling an issue as part of the Horizontal Security review). Chairs, staff, and editors are responsible to set those labels accordingly. Similarly, when issues are waiting for external reviewers to react, labels will be used to signal the status of the issue. (See the [current set of labels](https://github.com/w3c/did-syntax/labels).)
+GitHub issues are also used as a records of wide reviews, of horizontal
+reviews, etc. The Working Group will define a number of labels (e.g.,
+labeling an issue as part of the Horizontal Security review). Chairs,
+staff, and editors are responsible to set those labels accordingly.
+Similarly, when issues are waiting for external reviewers to react, labels
+will be used to signal the status of the issue. (See the
+[current set of labels](https://github.com/w3c/did-spec/labels).)
 
 ### Mailing lists (Policy, Usage, Etiquette, etc.)
 
-Although it is expected that a large portion of the technical discussion will happen via the issues mechanism of GitHub, the primary mailing list may also be used for overarching technical as well as business, outreach, administrative, etc, topics. We expect our mail list participants to adhere to the following email etiquette:
+Although it is expected that a large portion of the technical discussion
+will happen via the issues mechanism of GitHub, the primary mailing list
+may also be used for overarching technical as well as business, outreach,
+administrative, etc., topics. We expect our mail list participants to
+adhere to the following email etiquette:
 
-* Messages should be encoded using [plain text](http://en.wikipedia.org/wiki/Plain_text). Formats using [*rich text*](https://en.wikipedia.org/wiki/Rich_Text_Format) will be lost by the list archives and appear poorly to many readers before they get that far.
-* Subjects should be prefaced with the *short name* of the spec, if applicable (for example: `[Spec] Blah, Blah, Blah`)
+* Messages should be encoded using [plain text](http://en.wikipedia.org/wiki/Plain_text). 
+    Formats using [*rich text*](https://en.wikipedia.org/wiki/Rich_Text_Format)
+    will be lost by the list archives and appear poorly to many readers
+    before they get that far.
+* Subjects should be prefaced with the *short name* of the spec, if
+    applicable (for example: `[Spec] Blah, Blah, Blah`)
 * When you reply to a message, please use “> ” as your quotation character.
-* Do not prefix your content with something like “[myname]”. Your content will be visible to everyone because it will *not* be prefixed by the quotation character (“> ”).
+* Do not prefix your content with something like “[myname]”. Your content
+    will be visible to everyone because it will *not* be prefixed by the
+    quotation character (“> ”).
 * Do strip quoted text which is not relevant to your reply.
-* Do not write in ALL CAPS. It is considered bad form. If you need to \_underscore\_ something, you can do so as such, if you wanted to \*strengthen\* something you can similarly, and if you want to provide a certain \/italics\/ style, you may do that as well.
-* Your messages are archived. If you need to include links within your message, please use `[n]` notation inline (e.g., [1]), and include the relevant links at the end of the message. (Just like in a scholarly paper…)
-* Attachments must follow the [W3C Guidelines for Email Attachment Formats](https://www.w3.org/2002/03/email_attachment_formats.html), in particular:
+* Do not write in ALL CAPS. It is considered bad form. If you need to
+    \_underscore\_ something, you can do so as such, if you wanted to
+    \*strengthen\* something you can similarly, and if you want to provide
+    a certain \/italics\/ style, you may do that as well.
+* Your messages are archived. If you need to include links within your
+    message, please use `[n]` notation inline (e.g., [1]), and include the
+    relevant links at the end of the message. (Just like in a scholarly paper…)
+* Attachments must follow the 
+    [W3C Guidelines for Email Attachment Formats](https://www.w3.org/2002/03/email_attachment_formats.html),
+    in particular:
 	* Avoid unnecessary email attachments.
-	* Use an attachment only when it is likely to benefit to recipients. Otherwise, place the information (in plain text format) in the body of your message.
-	* If an attachment is necessary, avoid formats that are virus prone, proprietary or platform dependent.  For example, whenever possible you should use HTML instead of MS Word, PowerPoint or PDF.
+	* Use an attachment only when it is likely to benefit to recipients.
+	    Otherwise, place the information (in plain text format) in the body
+	    of your message.
+	* If an attachment is necessary, avoid formats that are virus prone,
+	    proprietary or platform dependent.  For example, whenever possible
+	    you should use HTML instead of MS Word, PowerPoint or PDF.
 	* Follow [Web Content Accessibility Guidelines](//www.w3.org/TR/WAI-WEBCONTENT/) (WCAG)
 
 ### IRC
 {: #irc}
 
-The group uses the `#did` channel of the W3C’s IRC system (irc.w3.org; port 6667). Task forces may freely set up their own, specific channels.
+The group uses the `#did` channel of the W3C’s IRC system (irc.w3.org; port 6667).
+Task forces may freely set up their own, specific channels.
 
-An [HTML interface to the W3C's IRC system](http://irc.w3.org/) is available. See [Meeting Resources](../Meetings/) for more information about the W3C’s IRC system and its usage.
+An [HTML interface to the W3C's IRC system](http://irc.w3.org/) is
+available. See [Meeting Resources](../Meetings/) for more information about
+the W3C’s IRC system and its usage.
 
 ### Wiki(s)
 
-Each repository, including the “core” WG repository, has a wiki instance. Members of the Working Groups are encouraged to use those for temporary discussions, documents, etc. Pages on the repository Wikis have no formal status.
+Each repository, including the “core” WG repository, has a wiki instance.
+Members of the Working Groups are encouraged to use those for temporary
+discussions, documents, etc. Pages on the repository Wikis have no formal
+status.
 
 ## Process
 
-The [Charter](https://www.w3.org{{ site.charter }}) and the [W3C Process Document](https://www.w3.org/Consortium/Process/) are the final arbiters of any process question, however the Working Group has adopted some complimentary, additional processes to aid in its productivity.
+The [Charter](https://www.w3.org{{ site.charter }}) and the
+[W3C Process Document](https://www.w3.org/Consortium/Process/) are the
+final arbiters of any process question, however the Working Group has
+adopted some complimentary, additional processes to aid in its productivity.
 
-* Adoption of [guiding technical principles](guiding_principles) towards quickly coming to consensus
+* Adoption of [guiding technical principles](guiding_principles) towards
+    quickly coming to consensus
+* In order to balance the need for group consensus and the need to move the
+    work forward at a reasonable pace, we will not require most of the
+    group's decisions to be made via formal resolutions. 
+    * This will free the Editors to merge PRs and close Issues as soon as
+        they feel the group has reached consensus.
+    * Editors will attempt to reach out to interested parties, but it is up
+        to WG members to actively monitor progress.
+    * Any decision to merge may be challenged during a 48-hour window
+        following the decision.
+* It is encouraged that any Pull Request which changes the normative text
+    of the [DID Specification](https://github.com/w3c/did-spec) will be
+    accompanied by an equivalent Pull Request which changes the appropriate
+    tests in the [Test Suite](https://github.com/w3c/did-test-suite).
+    
 
 
 ## Patent Policy
 
-The WG's Charter defines the [Patent Policy for this group](https://www.w3.org{{ site.charter }}#patentpolicy):
+The WG's Charter defines the
+[Patent Policy for this group](https://www.w3.org{{ site.charter }}#patentpolicy):
 
-> This Working Group operates under the [W3C Patent Policy](//www.w3.org/Consortium/Patent-Policy-20040205/) (5 February 2004 Version). To promote the widest adoption of Web standards, W3C seeks to issue Recommendations that can be implemented, according to this policy, on a Royalty-Free basis. For more information about disclosure obligations for this group, please see the [W3C Patent Policy Implementation](//www.w3.org/2004/01/pp-impl/).
+> This Working Group operates under the 
+    [W3C Patent Policy](//www.w3.org/Consortium/Patent-Policy-20040205/)
+    (5 February 2004 Version). To promote the widest adoption of Web
+    standards, W3C seeks to issue Recommendations that can be implemented,
+    according to this policy, on a Royalty-Free basis. For more information
+    about disclosure obligations for this group, please see the
+    [W3C Patent Policy Implementation](//www.w3.org/2004/01/pp-impl/).
 
-A consequence of the group’s Patent Policy is that, although comments from non-WG participants are welcome, in general, specific contributions for the group's specifications from non-WG participants are not permitted. See the W3C Patent Policy FAQ titled [*How should Working Groups handle contributions from non-participants (e.g., meeting guests or on public lists)?*](https://www.w3.org/2003/12/22-pp-faq.html#non-participants) for more information about contributions from non-WG participants. Non-WG participants may contribute to the group's specifications if they have agreed to the terms in [*Licensing commitments from non-W3C Members*](https://www.w3.org/2004/01/pp-impl/100074/nmlc).
+A consequence of the group’s Patent Policy is that, although comments from
+non-WG participants are welcome in general, specific contributions for the
+group's specifications from non-WG participants are not permitted. See the
+W3C Patent Policy FAQ titled
+[*How should Working Groups handle contributions from non-participants (e.g., meeting guests or on public lists)?*](https://www.w3.org/2003/12/22-pp-faq.html#non-participants)
+for more information about contributions from non-WG participants. Non-WG
+participants may contribute to the group's specifications if they have
+agreed to the terms in
+[*Licensing commitments from non-W3C Members*](https://www.w3.org/2004/01/pp-impl/100074/nmlc).
 
 ## Code of Conduct
 
-The WG follows the W3C [Code of Ethics and Professional Conduct](https://www.w3.org/Consortium/cepc/).
+The WG follows the W3C
+[Code of Ethics and Professional Conduct](https://www.w3.org/Consortium/cepc/).

--- a/WorkMode/newbie.md
+++ b/WorkMode/newbie.md
@@ -4,43 +4,93 @@ layout: default
 # Welcome to the DID Working Group
 {: .no_toc}
 
-This document includes some information for new members ("*Newbies*") of the DID Working Group (DID WG).
+This document includes some information for new members ("*Newbies*") of
+the DID Working Group (DID WG).
 
-Members of the WG, **especially new members** are encouraged to help maintain this document.
+Members of the WG, **especially new members** are encouraged to help
+maintain this document.
 
 * TOC
 {:toc}
 
-The Working Group’s home page is: [https://www.w3.org/2019/did-wg/](https://www.w3.org/2019/did-wg/). Looking at the left and right column of the page gives you lots of further information. Especially, the group's *Work Mode* is described in the [*WorkMode*](index) document and it includes information about how the WG operates, including links to the WG's various resources.
+The Working Group’s home page is:
+[https://www.w3.org/2019/did-wg/](https://www.w3.org/2019/did-wg/). Looking
+at the left and right column of the page gives you lots of further
+information. Especially, the group's *Work Mode* is described in the
+[*WorkMode*](index) document and it includes information about how the WG
+operates, including links to the WG's various resources.
 
 ## Meetings
 
-The group holds a weekly teleconference; see [the separate page](../Meetings/) for the timing and the dial-in details.
+The group holds a weekly teleconference; see
+[the times and dial-in details](../Meetings/).
 
 ## GitHub
 
-The group operates mostly on [GitHub](index#github): that is where the specifications are developed, where issues are discussed. Even these pages are in a GitHub repository (look at the bottom for the reference). It is therefore important to familiarize yourself, at least at a basic level, with this tool. (If you are new to GitHub, the [*“Introduction to Basic GitHub Contribution”*](https://iherman.github.io/misc-notes/docs/BasicGitHubContributionIntro) may be of help.)
+The group operates mostly on [GitHub](index#github): that is where the
+specifications are developed, where issues are discussed. Even these pages
+are in a GitHub repository (look at the bottom for the reference). It is
+therefore important to familiarize yourself, at least at a basic level,
+with this tool. (If you are new to GitHub, the
+[*“Introduction to Basic GitHub Contribution”*](https://iherman.github.io/misc-notes/docs/BasicGitHubContributionIntro)
+may be of help.)
 
-Once you have your GitHub account name, **send this name to ivan@w3.org, or to one of the chairs**, who will add you to the Working Group’s “GitHub team” (in GitHub‘s jargon). That would give you the possibility of being asked personally to review or being assigned to issues, or editing the wiki pages.
+Once you have your GitHub account name, **send this name to ivan@w3.org, or
+to one of the chairs**, who will add you to the Working Group’s “GitHub
+team” (in GitHub‘s jargon). That would give you the possibility of being
+asked personally to review or be assigned to issues, or to edit the wiki
+pages.
 
-You should also "link" your GitHub account to your W3C account; this can be done by going to the [relevant page](https://www.w3.org/users/myprofile/connectedaccounts) on your account. Doing so ensures that the various W3C specific tools can check your identity whether you use your W3C account or your GitHub account. As an example, if you do a Pull Request on one of the Recommendation track documents on GitHub, the system would know that you are bona fide Working Group member, which means that the possible IPR issues are properly handled by virtue of your institution’s Working Group membership.
+You should also "link" your GitHub account to your W3C account; this can be
+done by going to the
+[relevant page](https://www.w3.org/users/myprofile/connectedaccounts) on
+your account. Doing so ensures that the various W3C specific tools can
+check your identity whether you use your W3C account or your GitHub
+account. As an example, if you do a Pull Request on one of the
+Recommendation track documents on GitHub, the system would know that you
+are a Working Group member, which means that the possible IPR issues are
+properly handled by virtue of your institution’s Working Group membership.
 
 ## IRC
 
-Meetings usually use [IRC](index#irc) as a tool for queue control and minute taking (and general chit-chat). **You should also send to ivan@w3.org your preferred IRC nickname (or nicknames, if you use several of those).** The goal is to improve the readability of the meeting minutes, so that third parties could also understand whose comments and remarks are in the minutes. Actually, in case you are already a seasoned GitHub user: the nicknames are stored (of course:-) in [file on GitHub](https://github.com/w3c/did-wg/blob/master/assets/nicknames.json), meaning that you can simply make a pull request providing with with your nickname(s) instead of a mail.
+Meetings usually use [IRC](index#irc) as a tool for queue control and
+minute taking (and general chit-chat). **You should also send ivan@w3.org
+your preferred IRC nickname (or nicknames, if you use several of those).**
+The goal is to improve the readability of the meeting minutes, so that
+third parties can also understand whose comments and remarks are in the
+minutes. Actually, in case you are already a seasoned GitHub user: the
+nicknames are stored (of course:-) in a
+[file on GitHub](https://github.com/w3c/did-wg/blob/master/assets/nicknames.json),
+meaning that you can simply make a pull request adding your nickname(s)
+instead of sending an e-mail.
 
 ## Specifications in Progress
 
-A list of the group’s specifications, including the publication status of each spec, can be found in the group’s [*PubStatus*](https://www.w3.org/2018/did-wg/PublStatus) document.
+A list of the group’s specifications, including the publication status of
+each spec, can be found in the group’s
+[*PubStatus*](https://www.w3.org/2019/did-wg/PublStatus) document.
 
 ## New WG Member Introductions
 
-Although it isn’t required, **new WG members are encouraged to send a short introductory e-mail to the WG's Public mail list** ([public-did-wg@w3.org](https://lists.w3.org/Archives/Public/public-did-wg/)) or the group’s Member-only list ([member-did-wg@w3.org](https://lists.w3.org/Archives/Member/member-did-wg/)). The introduction should include your area(s) of interest.
+Although it isn’t required, **new WG members are encouraged to send a short
+introductory e-mail to the WG's Public mail list**
+([public-did-wg@w3.org](https://lists.w3.org/Archives/Public/public-did-wg/))
+or the group’s Member-only list
+([member-did-wg@w3.org](https://lists.w3.org/Archives/Member/member-did-wg/)).
+The introduction should include your area(s) of interest.
+
+New WG members may also be invited to introduce themselves during a 
+teleconference meeting.
 
 ## Questions, Comments, Issues, etc.?
 
-Please contact the group's Chairs and staff contacts (using the [group-did-wg-chairs@w3.org](mailto:group-did-wg-chairs@w3.org) list) — *at any time* — if you have any questions, issues, concerns, etc. about the Working Group.
+Please contact the group's Chairs and staff contacts (using the
+[group-did-wg-chairs@w3.org](mailto:group-did-wg-chairs@w3.org) list) — *at
+any time* — if you have any questions, issues, concerns, etc. about the
+Working Group.
 
 ## Resources
 
-If you are unfamiliar with processes and roles within the Consortium; there is an [introduction course](http://lists.w3.org/Archives/Public/www-archive/2014Apr/0026.html) available which takes little over an hour and a half to complete.
+If you are unfamiliar with processes and roles within the Consortium; there
+is an [introduction course](http://lists.w3.org/Archives/Public/www-archive/2014Apr/0026.html)
+available which takes little over an hour and a half to complete.

--- a/WorkMode/newbie.md
+++ b/WorkMode/newbie.md
@@ -37,7 +37,7 @@ may be of help.)
 
 Once you have your GitHub account name, **send this name to ivan@w3.org, or
 to one of the chairs**, who will add you to the Working Group’s “GitHub
-team” (in GitHub‘s jargon). That would give you the possibility of being
+team” (in GitHub‘s jargon). That would enable you to be
 asked personally to review or be assigned to issues, or to edit the wiki
 pages.
 
@@ -55,11 +55,11 @@ properly handled by virtue of your institution’s Working Group membership.
 
 Meetings usually use [IRC](index#irc) as a tool for queue control and
 minute taking (and general chit-chat). **You should also send ivan@w3.org
-your preferred IRC nickname (or nicknames, if you use several of those).**
+your preferred IRC nickname(s).**
 The goal is to improve the readability of the meeting minutes, so that
 third parties can also understand whose comments and remarks are in the
-minutes. Actually, in case you are already a seasoned GitHub user: the
-nicknames are stored (of course:-) in a
+minutes. If you are already a seasoned GitHub user: the
+IRC and GitHub nicknames are stored (of course :-) ) in a
 [file on GitHub](https://github.com/w3c/did-wg/blob/master/assets/nicknames.json),
 meaning that you can simply make a pull request adding your nickname(s)
 instead of sending an e-mail.
@@ -86,11 +86,11 @@ teleconference meeting.
 
 Please contact the group's Chairs and staff contacts (using the
 [group-did-wg-chairs@w3.org](mailto:group-did-wg-chairs@w3.org) list) — *at
-any time* — if you have any questions, issues, concerns, etc. about the
+any time* — if you have any questions, issues, concerns, etc., about the
 Working Group.
 
 ## Resources
 
 If you are unfamiliar with processes and roles within the Consortium; there
 is an [introduction course](http://lists.w3.org/Archives/Public/www-archive/2014Apr/0026.html)
-available which takes little over an hour and a half to complete.
+available which typically takes about 90 minutes to complete.


### PR DESCRIPTION
Working mode: line length, link fixes, minor edits, added content from 01-10-19 meeting

The changes will be more easily reviewed using `rich diff` rather than `source diff`

Signed-off-by: Brent <brent.zundel@gmail.com>