### PR TITLE
The wiki isn't enabled on github.com/w3c/did-wg

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -8,7 +8,7 @@
         <li><a href="{{ site.baseurl }}/WorkMode/">WorkMode</a></li>
         <li><a href="{{ site.baseurl }}/WorkMode/getting-started">Information for new members</a></li>
         <li><a href="{{ site.baseurl }}/Misc/publishing">Publishing Workflow</a></li>
-        <li><a rel="external" href="https://github.com/w3c/{{ site.wgname_lc }}-wg/wiki"><abbr title="Working Group">WG</abbr> Wiki</a></li>
+        <!-- <li><a rel="external" href="https://github.com/w3c/{{ site.wgname_lc }}-wg/wiki"><abbr title="Working Group">WG</abbr> Wiki</a></li> -->
         <!-- <li><a href="https://www.w3.org/did-wg/Misc/presentations">Public Presentations</a></li> -->
         <li><a rel="external" href="https://www.w3.org/Consortium/join">Join the W3C</a></li>
         <li><a rel="external" href="https://www.w3.org/2004/01/pp-impl/{{ site.groupid }}/join">Join the Working Group</a></li>


### PR DESCRIPTION
The link redirects, so it was confusing me. I'm guessing that the repo hasn't enabled the wiki feature.