### PR TITLE
fix speaker attribution and one comment for meeting notes 26 January 2021

### DIFF
--- a/_minutes/2021-01-26-did.md
+++ b/_minutes/2021-01-26-did.md
@@ -167,14 +167,14 @@ See also the [Agenda](https://lists.w3.org/Archives/Public/public-did-wg/2021Jan
 ### 1. PR Deadline
 {: #section1}
 
-**Daniel Burnett:** Sent out a notice a while back, you all should now have it  
+**Brent Zundel:** Sent out a notice a while back, you all should now have it  
 … the PR deadline is Feb 9  
 … Any PRs not raised by that day will be deferred to vNext  
 
 ### 2. Special topic call
 {: #section2}
 
-**Daniel Burnett:** Will be this Thursday  
+**Brent Zundel:** Will be this Thursday  
 … Purpose of the call is for anyone writing PRs to get feedback, guidance, aid, etc.  
 … Noon EST, on Thurs  
 
@@ -183,7 +183,7 @@ See also the [Agenda](https://lists.w3.org/Archives/Public/public-did-wg/2021Jan
 ### 3. Various WG Notes
 {: #section3}
 
-**Daniel Burnett:** Hoping to do a quick roundtable about some of the Notes that are being written  
+**Brent Zundel:** Hoping to do a quick roundtable about some of the Notes that are being written  
 … Use cases is very nearly completely complete  
 
 **Joe Andrieu:** on the rubric: Daniel Hardman and I are meeting each week to push it forward  
@@ -191,8 +191,8 @@ See also the [Agenda](https://lists.w3.org/Archives/Public/public-did-wg/2021Jan
 … Rubric proposed by that group as a starting point  
 … Will take the feedback in incorporate it into the Rubric  
 
-**Daniel Burnett:** Test suite is the other major item  
-… Orie threatens to refactor, then made good on his threat!  
+**Brent Zundel:** Test suite is the other major item  
+**Orie Steele:** The test suite has been refactored.  
 … Open PR in test suite repo. Open issue as to whether the test suite is about DID Method conformance or other variety of conformance  
 
 > *Orie Steele:* [https://github.com/w3c/did-test-suite/pull/19](https://github.com/w3c/did-test-suite/pull/19)


### PR DESCRIPTION
Signed-off-by: Brent Zundel <brent.zundel@gmail.com>